### PR TITLE
Fix browserslist support, added options to disable browserlist feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,26 +45,24 @@ By default, the plugin will report on all lookahead and lookbehind regexp as wel
 rules: {
    'no-lookahead-lookbehind-regexp/no-lookahead-lookbehind-regexp': [
       'error',
-      {
-         'no-lookahead': 1,
-         'no-negative-lookbehind': 1,
-      }
+      'no-lookahead',
+      'no-lookbehind',
+      'no-negative-lookahead',
+      'no-negative-lookbehind',
    ],
 }
 ```
 
 ## 5. Disable Browserslist Support
 
-By default, the plugin will use yours project's browserslist settings to find availability of lookahead/lookbehind and their negative bros. However, if you want to disable this feature to report all usages as errors, you can pass a second rule options as false.
+By default, the plugin will use yours project's browserslist settings to find availability of lookahead/lookbehind and their negative counterparts. However, if you want to disable this feature to report all usages(still controlled by above rules settings) as errors, you can pass an additional object options.
 
 ```js
 rules: {
    'no-lookahead-lookbehind-regexp/no-lookahead-lookbehind-regexp': [
       'error',
-      {
-         'no-lookahead': 1,
-      },
-      false
+      'no-lookahead',
+      { browserslist: false },
    ],
 }
 ```

--- a/README.md
+++ b/README.md
@@ -39,28 +39,32 @@ We use [browserslist](https://github.com/browserslist/browserslist) to resolve b
 
 ## 4. Customizing rules
 
-By default, the plugin will report on all lookahead and lookbehind regexp as well as their negative counterparts. To enable only individual rules like erroring only on lookbehind expressions, you can pass a list of rules that you wish to enable as options in your eslint. **Note that once a single rule is passed as a configuration option, all of the other rules are disabled by default and you are in full control.**
+By default, the plugin will report on all lookahead and lookbehind regexp as well as their negative counterparts(if they are not supported with above browserslist target settings). To enable only individual rules like erroring only on lookbehind expressions, you can pass a list of rules that you wish to enable as options in your eslint. **Note that once a single rule is passed as a configuration option, all of the other rules are disabled by default and you are in full control.**
 
 ```js
 rules: {
    'no-lookahead-lookbehind-regexp/no-lookahead-lookbehind-regexp': [
       'error',
-      'no-lookahead',
-      'no-lookbehind',
-      'no-negative-lookahead',
-      'no-negative-lookbehind',
+      {
+         'no-lookahead': 1,
+         'no-negative-lookbehind': 1,
+      }
    ],
 }
 ```
 
-As an example, passing both no-lookbehind and no-negative-lookbehind as options will cause the plugin to error on all lookbehind and negative lookbehind expressions, but it will not cause it to report errors on lookahead or negative lookahead expressions.
+## 5. Disable Browserslist Support
+
+By default, the plugin will use yours project's browserslist settings to find availability of lookahead/lookbehind and their negative bros. However, if you want to disable this feature to report all usages as errors, you can pass a second rule options as false.
 
 ```js
 rules: {
    'no-lookahead-lookbehind-regexp/no-lookahead-lookbehind-regexp': [
       'error',
-      'no-lookbehind',
-      'no-negative-lookbehind',
+      {
+         'no-lookahead': 1,
+      },
+      false
    ],
 }
 ```

--- a/benchmark/benchmark.ts
+++ b/benchmark/benchmark.ts
@@ -21,7 +21,7 @@ const config = {
 
 const eslint = new ESLint(config);
 const benchmark = new Benchmark(
-  "ESLint self benchmark w/o browserlist",
+  "ESLint self benchmark w/o browserslist",
   (deferred: { resolve: Function }) => {
     eslint
       .lintFiles("src/**/*.ts")
@@ -63,7 +63,7 @@ eslint
   });
 
 const browserlistBenchmark = new Benchmark(
-  "ESLint self benchmark with browserlist",
+  "ESLint self benchmark with browserslist",
   (deferred: { resolve: Function; reject: Function }) => {
     eslint
       .lintFiles("src/**/*.ts")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-no-lookahead-lookbehind-regexp",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": "git@github.com:JonasBa/eslint-plugin-no-lookahead-lookbehind-regexp.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-no-lookahead-lookbehind-regexp",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": "git@github.com:JonasBa/eslint-plugin-no-lookahead-lookbehind-regexp.git",
@@ -12,7 +12,6 @@
   },
   "scripts": {
     "benchmark": "ts-node test/benchmark.ts",
-    "prepare": "yarn test && yarn build",
     "build": "rm -rf ./lib && yarn tsc",
     "tsc": "tsc",
     "test": "jest",

--- a/src/helpers/analyzeRegExpForLookaheadAndLookbehind.test.ts
+++ b/src/helpers/analyzeRegExpForLookaheadAndLookbehind.test.ts
@@ -11,7 +11,7 @@ describe("analyzeRegExpForLookaheadAndLookbehind", () => {
     for (const group of groups) {
       expect(
         analyzeRegExpForLookaheadAndLookbehind(`\\(${group}`, {
-          rules: getExpressionsToCheckFromConfiguration([]),
+          rules: getExpressionsToCheckFromConfiguration([]).rules,
         }).length
       ).toBe(0);
     }
@@ -25,7 +25,7 @@ describe("analyzeRegExpForLookaheadAndLookbehind", () => {
   ])(`Single match %s - at %i`, (type, position, expression) => {
     expect(
       analyzeRegExpForLookaheadAndLookbehind(expression, {
-        rules: getExpressionsToCheckFromConfiguration([]),
+        rules: getExpressionsToCheckFromConfiguration([]).rules,
       })[0]
     ).toEqual({
       type: type.replace("negative ", ""),
@@ -42,7 +42,7 @@ describe("analyzeRegExpForLookaheadAndLookbehind", () => {
   ])(`Multiple match %s - at %i and %i`, (type, first, second, expression) => {
     expect(
       analyzeRegExpForLookaheadAndLookbehind(expression, {
-        rules: getExpressionsToCheckFromConfiguration([]),
+        rules: getExpressionsToCheckFromConfiguration([]).rules,
       })
     ).toEqual([
       {
@@ -83,7 +83,7 @@ describe("analyzeRegExpForLookaheadAndLookbehind", () => {
       } else {
         expect(
           analyzeRegExpForLookaheadAndLookbehind(expressions[expression], {
-            rules: getExpressionsToCheckFromConfiguration([]),
+            rules: getExpressionsToCheckFromConfiguration([]).rules,
           })
         ).toEqual([
           {

--- a/src/helpers/analyzeRegExpForLookaheadAndLookbehind.test.ts
+++ b/src/helpers/analyzeRegExpForLookaheadAndLookbehind.test.ts
@@ -10,9 +10,10 @@ describe("analyzeRegExpForLookaheadAndLookbehind", () => {
   it("does not return false positives for an escaped sequence", () => {
     for (const group of groups) {
       expect(
-        analyzeRegExpForLookaheadAndLookbehind(`\\(${group}`, {
-          rules: getExpressionsToCheckFromConfiguration([]).rules,
-        }).length
+        analyzeRegExpForLookaheadAndLookbehind(
+          `\\(${group}`,
+          getExpressionsToCheckFromConfiguration([]).rules
+        ).length
       ).toBe(0);
     }
   });
@@ -24,9 +25,10 @@ describe("analyzeRegExpForLookaheadAndLookbehind", () => {
     ["negative lookbehind", 0, "(?<!)"],
   ])(`Single match %s - at %i`, (type, position, expression) => {
     expect(
-      analyzeRegExpForLookaheadAndLookbehind(expression, {
-        rules: getExpressionsToCheckFromConfiguration([]).rules,
-      })[0]
+      analyzeRegExpForLookaheadAndLookbehind(
+        expression,
+        getExpressionsToCheckFromConfiguration([]).rules
+      )[0]
     ).toEqual({
       type: type.replace("negative ", ""),
       position: position,
@@ -41,9 +43,10 @@ describe("analyzeRegExpForLookaheadAndLookbehind", () => {
     ["negative lookbehind", 0, 8, "(?<!t).*(?<!t)"],
   ])(`Multiple match %s - at %i and %i`, (type, first, second, expression) => {
     expect(
-      analyzeRegExpForLookaheadAndLookbehind(expression, {
-        rules: getExpressionsToCheckFromConfiguration([]).rules,
-      })
+      analyzeRegExpForLookaheadAndLookbehind(
+        expression,
+        getExpressionsToCheckFromConfiguration([]).rules
+      )
     ).toEqual([
       {
         type: type.replace("negative ", ""),
@@ -76,15 +79,14 @@ describe("analyzeRegExpForLookaheadAndLookbehind", () => {
     for (const expression in expressions) {
       if (rule === expression) {
         expect(
-          analyzeRegExpForLookaheadAndLookbehind(expressions[expression], {
-            rules: { [expression]: 0 },
-          })
+          analyzeRegExpForLookaheadAndLookbehind(expressions[expression], { [expression]: 0 })
         ).toEqual([]);
       } else {
         expect(
-          analyzeRegExpForLookaheadAndLookbehind(expressions[expression], {
-            rules: getExpressionsToCheckFromConfiguration([]).rules,
-          })
+          analyzeRegExpForLookaheadAndLookbehind(
+            expressions[expression],
+            getExpressionsToCheckFromConfiguration([]).rules
+          )
         ).toEqual([
           {
             position: 0,

--- a/src/helpers/analyzeRegExpForLookaheadAndLookbehind.ts
+++ b/src/helpers/analyzeRegExpForLookaheadAndLookbehind.ts
@@ -6,6 +6,7 @@ export type CheckableExpression =
 
 export type AnalyzeOptions = {
   rules: Partial<{ [key in `no-${CheckableExpression}`]: 0 | 1 }>;
+  conf: Partial<{ browserslist: boolean }>;
 };
 
 type UnsupportedExpression = {
@@ -16,7 +17,7 @@ type UnsupportedExpression = {
 
 function analyzeRegExpForLookaheadAndLookbehind(
   input: string,
-  options: AnalyzeOptions
+  rules: AnalyzeOptions["rules"]
 ): UnsupportedExpression[] {
   // Lookahead and lookbehind require min 5 characters to be useful, however
   // an expression like /(?=)/ which uses only 4, although not useful, can still crash an application
@@ -47,7 +48,7 @@ function analyzeRegExpForLookaheadAndLookbehind(
 
           // Lookahead
           if (peek() === "=") {
-            if (options.rules["no-lookahead"]) {
+            if (rules["no-lookahead"]) {
               matchedExpressions.push({
                 type: "lookahead",
                 position: start,
@@ -58,7 +59,7 @@ function analyzeRegExpForLookaheadAndLookbehind(
           }
           // Negative lookahead
           if (peek() === "!") {
-            if (options.rules["no-negative-lookahead"]) {
+            if (rules["no-negative-lookahead"]) {
               matchedExpressions.push({
                 type: "lookahead",
                 negative: 1,
@@ -72,7 +73,7 @@ function analyzeRegExpForLookaheadAndLookbehind(
           // Lookbehind
           if (peek() === "<") {
             if (input.charAt(current + 2) === "=") {
-              if (options.rules["no-lookbehind"]) {
+              if (rules["no-lookbehind"]) {
                 matchedExpressions.push({
                   type: "lookbehind",
                   position: start,
@@ -84,7 +85,7 @@ function analyzeRegExpForLookaheadAndLookbehind(
             }
             // Negative Lookbehind
             if (input.charAt(current + 2) === "!") {
-              if (options.rules["no-negative-lookbehind"]) {
+              if (rules["no-negative-lookbehind"]) {
                 matchedExpressions.push({
                   type: "lookbehind",
                   negative: 1,

--- a/src/helpers/createReport.ts
+++ b/src/helpers/createReport.ts
@@ -1,14 +1,14 @@
 import * as ESTree from "estree";
 import { Rule } from "eslint";
 
-import { analyzeRegExpForLookaheadAndLookbehind } from "./../helpers/analyzeRegExpForLookAheadAndLookbehind";
-import { collectUnsupportedTargets, formatLinterMessage } from "./../helpers/caniuse";
+import { analyzeRegExpForLookaheadAndLookbehind } from "../helpers/analyzeRegExpForLookaheadAndLookbehind";
+import { collectUnsupportedTargets, formatLinterMessage } from "../helpers/caniuse";
 
 export function createContextReport(
   node: ESTree.Literal & Rule.NodeParentExtension,
   context: Rule.RuleContext,
   violators: ReturnType<typeof analyzeRegExpForLookaheadAndLookbehind>,
-  targets: ReturnType<typeof collectUnsupportedTargets>
+  targets: ReturnType<typeof collectUnsupportedTargets>,
 ): void {
   context.report({
     node: node,

--- a/src/rules/noLookAheadLookBehindRegExp.test.ts
+++ b/src/rules/noLookAheadLookBehindRegExp.test.ts
@@ -1,7 +1,7 @@
 import { RuleTester } from "eslint";
 import { noLookaheadLookbehindRegexp } from "./noLookaheadLookbehindRegex";
 
-// Rule tester for when no browserlist is passed, so lookahead and lookbehind should not be allowed
+// Rule tester for when no browserslist is passed, so lookahead and lookbehind should not be allowed
 const tester = new RuleTester({
   parser: require.resolve("@typescript-eslint/parser"),
   parserOptions: {


### PR DESCRIPTION
New features:
- bumping up minor version for a new but compatible  option
- new option to disable browserslist support(to enforce no usages even though browsers are supported)

      rules: {
        'no-lookahead-lookbehind-regexp/no-lookahead-lookbehind-regexp': [
          'error',
          'no-lookahead',
       + { browserslist: false }
       ],
      }

Fixed:
- fix browserslist feature, eg: currently plugin will report lookahead errors even though lookahead is supported
   ![image](https://github.com/JonasBa/eslint-plugin-no-lookahead-lookbehind-regexp/assets/5621862/0b90b6ff-1fcd-4f96-963f-8f5525ea7919)
   ![image](https://github.com/JonasBa/eslint-plugin-no-lookahead-lookbehind-regexp/assets/5621862/fe454d20-5967-4ff3-b2c6-6d09ac1270c3)
   ![image](https://github.com/JonasBa/eslint-plugin-no-lookahead-lookbehind-regexp/assets/5621862/9e8234dd-1591-4b5b-a2bf-c784988a61cf)

Breaking Changes: none