### PR TITLE
Extend rule to look into Template Literal and BinaryExpressions

### DIFF
--- a/src/helpers/ast.ts
+++ b/src/helpers/ast.ts
@@ -15,3 +15,7 @@ export function isStringLiteralRegExp(literal: Literal & Rule.NodeParentExtensio
     literal.parent.callee.name === "RegExp"
   );
 }
+
+export function isBinaryExpression(literal: Literal & Rule.NodeParentExtension) {
+  return literal.parent !== null && literal.parent.type === "BinaryExpression";
+}

--- a/src/helpers/createReport.ts
+++ b/src/helpers/createReport.ts
@@ -7,8 +7,12 @@ import {
 } from "../helpers/analyzeRegExpForLookaheadAndLookbehind";
 import { collectUnsupportedTargets, formatLinterMessage } from "../helpers/caniuse";
 
+type NodeToReport =
+  | (ESTree.Literal & Rule.NodeParentExtension)
+  | (ESTree.TemplateLiteral & Rule.NodeParentExtension);
+
 export function createContextReport(
-  node: ESTree.Literal & Rule.NodeParentExtension,
+  node: NodeToReport,
   context: Rule.RuleContext,
   violators: ReturnType<typeof analyzeRegExpForLookaheadAndLookbehind>,
   targets: ReturnType<typeof collectUnsupportedTargets>,

--- a/src/rules/noLookAheadLookBehindRegExp.test.ts
+++ b/src/rules/noLookAheadLookBehindRegExp.test.ts
@@ -70,6 +70,56 @@ tester.run("noLookaheadLookbehindRegexp", noLookaheadLookbehindRegexp, {
         ],
       };
     }),
+    ...groups.map((g) => {
+      return {
+        code: `new RegExp("(${g.expression})" + "")`,
+        errors: [
+          {
+            message: `Disallowed ${g.type} match group at position 1`,
+          },
+        ],
+      };
+    }),
+    ...groups.map((g) => {
+      return {
+        code: `new RegExp("" + "(${g.expression})")`,
+        errors: [
+          {
+            message: `Disallowed ${g.type} match group at position 1`,
+          },
+        ],
+      };
+    }),
+    ...groups.map((g) => {
+      return {
+        code: `new RegExp("" + "(${g.expression})" + "")`,
+        errors: [
+          {
+            message: `Disallowed ${g.type} match group at position 1`,
+          },
+        ],
+      };
+    }),
+    ...groups.map((g) => {
+      return {
+        code: `new RegExp(\`(${g.expression})\`)`,
+        errors: [
+          {
+            message: `Disallowed ${g.type} match group at position 0`,
+          },
+        ],
+      };
+    }),
+    ...groups.map((g) => {
+      return {
+        code: `new RegExp(\`some expression (${g.expression})\`)`,
+        errors: [
+          {
+            message: `Disallowed ${g.type} match group at position 16`,
+          },
+        ],
+      };
+    }),
   ],
 });
 


### PR DESCRIPTION
Fixes https://github.com/JonasBa/eslint-plugin-no-lookahead-lookbehind-regexp/issues/7

--- 

This Pull Request is improving the lint rule to check more edge cases, like:

```
new RegExp("(?<=)" + "");
new RegExp(`(?<=)`);
```

However, it still doesn't cover this kind of scenario:

```
const foo = "(?<=)";
new RegExp(`some content ${foo}`);
```

That would require a little bit of more code.