### PR TITLE
Prep for publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-no-lookahead-lookbehind-regexp",
-  "version": "0.4.0",
+  "version": "0.4.0-benchling",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": {
@@ -16,6 +16,7 @@
   "scripts": {
     "benchmark": "ts-node benchmark/benchmark.ts",
     "build": "rm -rf ./lib && yarn tsc",
+    "prepack": "yarn build",
     "tsc": "tsc",
     "test": "jest",
     "test:watch": "jest --watch"


### PR DESCRIPTION
We run `yarn pack`, so we need to build before that. Also set a custom version string, in case the real one is ever published.